### PR TITLE
enable indent again

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,12 +84,10 @@ module.exports = {
         "curly": "error",
 
         /*
-         * "indent": ["error", 2, { SwitchCase: 1 }],
-         * 
-         * Enforces a very specific level of indenting, which can be difficult to control 
-         * between editors.
+         * Default to qooxdoo pretty
          * 
          */
+        "indent": ["error", 2, { SwitchCase: 1 }],
         
         /*
          * "no-trailing-spaces": "error"


### PR DESCRIPTION
indent setting is necessary - otherwise --fix will give ugly results:
```
      var config = this.__config = await this.parse(this.argv);
      if (!config) {
throw new qx.tool.cli.Utils.UserError("Error: Cannot find any configuration");
}
      var maker = this.__maker = await this.createMakerFromConfig(config);
      if (!maker) {
throw new qx.tool.cli.Utils.UserError("Error: Cannot find anything to make");
}
```
Default should be 2 - this is the same value as pretty in python build