### PR TITLE
Revert "indent setting is necessary - otherwise --fix will give ugly results:"

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,10 +84,12 @@ module.exports = {
         "curly": "error",
 
         /*
-         * Default to qooxdoo pretty
+         * "indent": ["error", 2, { SwitchCase: 1 }],
+         * 
+         * Enforces a very specific level of indenting, which can be difficult to control 
+         * between editors.
          * 
          */
-        "indent": ["error", 2, { SwitchCase: 1 }],
         
         /*
          * "no-trailing-spaces": "error"


### PR DESCRIPTION
This reverts commit e5be59b5bc11e2aa452881f7f9c834a85e2eae52 from PR https://github.com/qooxdoo/eslint-config-qx/pull/2

The `indent` rule enforces strict rules on how to indent code; indentation is important for readability, but the implementation of this test is such that the exact level of indenting is enforced very precisely.  There is little readability to be gained from this strictness in practice, so much so that it's typically invisible to the human eye without careful study.  

On a practical basis, this requires that everybody's editor is configured to comply with exactly the rules implemented by eslint - which can be troublesome and/or conflict with established coding style for the contributor.  If your editor happens to disagree, then every commit is a constant battle between eslint and the editor, and it's hard to see the benefits of this rigidity.

I think also that there are occasions where (especially in large object literals) where the standard indentation and layout is simply unhelpful.  

As I understand it, the motivation for enabling this is because the `curly` rule is broken when using with `eslint --fix`, in that `curly` deletes indentation when adding curly brackets unless indentation is turned on - but a potential bug in eslint is not a justification for enforcing styling
